### PR TITLE
Adds support for locking the very own aspect ratio

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,6 +45,8 @@ ratio should be matched), then `AspectLockedFrameLayout` will reduce its height
 or width to maintain the requested aspect ratio. This affects the children of
 the `AspectLockedFrameLayout` as well, of course.
 
+You can also use `lockAspectRatioImmediately` or `lockAspectRatioOnLayoutChange` to straightaway lock the `AspectLockedFrameLayout` aspect ratio to its own.
+
 Since the `AspectLockedFrameLayout` effectively overrides and reduces its size,
 you can use `android:layout_gravity` to position the shrunken
 `AspectLockedFrameLayout` within its parent:

--- a/layouts/src/com/commonsware/cwac/layouts/AspectLockedFrameLayout.java
+++ b/layouts/src/com/commonsware/cwac/layouts/AspectLockedFrameLayout.java
@@ -1,135 +1,168 @@
 /***
-  Copyright (c) 2013 CommonsWare, LLC
-  Portions Copyright (C) 2009 The Android Open Source Project
-  
-  Licensed under the Apache License, Version 2.0 (the "License"); you may
-  not use this file except in compliance with the License. You may obtain
-  a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+ * Copyright (c) 2013 CommonsWare, LLC
+ * Portions Copyright (C) 2009 The Android Open Source Project
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package com.commonsware.cwac.layouts;
 
 import android.content.Context;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.ViewTreeObserver;
 import android.widget.FrameLayout;
 
 public class AspectLockedFrameLayout extends FrameLayout {
-  private double aspectRatio=0.0;
-  private AspectRatioSource aspectRatioSource=null;
+    private double aspectRatio = 0.0;
+    private AspectRatioSource aspectRatioSource = null;
 
-  public AspectLockedFrameLayout(Context context) {
-    super(context);
-  }
-
-  public AspectLockedFrameLayout(Context context, AttributeSet attrs) {
-    super(context, attrs);
-  }
-
-  // from com.android.camera.PreviewFrameLayout, with slight
-  // modifications
-
-  @Override
-  protected void onMeasure(int widthSpec, int heightSpec) {
-    double localRatio=aspectRatio;
-
-    if (localRatio == 0.0 && aspectRatioSource != null
-        && aspectRatioSource.getHeight() > 0) {
-      localRatio=
-          (double)aspectRatioSource.getWidth()
-              / (double)aspectRatioSource.getHeight();
+    public AspectLockedFrameLayout(Context context) {
+        super(context);
     }
 
-    if (localRatio == 0.0) {
-      super.onMeasure(widthSpec, heightSpec);
-    }
-    else {
-      int lockedWidth=MeasureSpec.getSize(widthSpec);
-      int lockedHeight=MeasureSpec.getSize(heightSpec);
-
-      if (lockedWidth == 0 && lockedHeight == 0) {
-        throw new IllegalArgumentException(
-                                           "Both width and height cannot be zero -- watch out for scrollable containers");
-      }
-
-      // Get the padding of the border background.
-      int hPadding=getPaddingLeft() + getPaddingRight();
-      int vPadding=getPaddingTop() + getPaddingBottom();
-
-      // Resize the preview frame with correct aspect ratio.
-      lockedWidth-=hPadding;
-      lockedHeight-=vPadding;
-
-      if (lockedHeight > 0 && (lockedWidth > lockedHeight * localRatio)) {
-        lockedWidth=(int)(lockedHeight * localRatio + .5);
-      }
-      else {
-        lockedHeight=(int)(lockedWidth / localRatio + .5);
-      }
-
-      // Add the padding of the border.
-      lockedWidth+=hPadding;
-      lockedHeight+=vPadding;
-
-      // Ask children to follow the new preview dimension.
-      super.onMeasure(MeasureSpec.makeMeasureSpec(lockedWidth,
-                                                  MeasureSpec.EXACTLY),
-                      MeasureSpec.makeMeasureSpec(lockedHeight,
-                                                  MeasureSpec.EXACTLY));
-    }
-  }
-
-  public void setAspectRatioSource(View v) {
-    this.aspectRatioSource=new ViewAspectRatioSource(v);
-  }
-
-  public void setAspectRatioSource(AspectRatioSource aspectRatioSource) {
-    this.aspectRatioSource=aspectRatioSource;
-  }
-
-  // from com.android.camera.PreviewFrameLayout, with slight
-  // modifications
-
-  public void setAspectRatio(double aspectRatio) {
-    if (aspectRatio <= 0.0) {
-      throw new IllegalArgumentException(
-                                         "aspect ratio must be positive");
+    public AspectLockedFrameLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
     }
 
-    if (this.aspectRatio != aspectRatio) {
-      this.aspectRatio=aspectRatio;
-      requestLayout();
-    }
-  }
-
-  public interface AspectRatioSource {
-    int getWidth();
-
-    int getHeight();
-  }
-
-  private static class ViewAspectRatioSource implements
-      AspectRatioSource {
-    private View v=null;
-
-    ViewAspectRatioSource(View v) {
-      this.v=v;
-    }
+    // from com.android.camera.PreviewFrameLayout, with slight
+    // modifications
 
     @Override
-    public int getWidth() {
-      return(v.getWidth());
+    protected void onMeasure(int widthSpec, int heightSpec) {
+        double localRatio = aspectRatio;
+
+        if (localRatio == 0.0 && aspectRatioSource != null
+                && aspectRatioSource.getHeight() > 0) {
+            localRatio =
+                    (double) aspectRatioSource.getWidth()
+                            / (double) aspectRatioSource.getHeight();
+        }
+
+        if (localRatio == 0.0) {
+            super.onMeasure(widthSpec, heightSpec);
+        }
+        else {
+            int lockedWidth = MeasureSpec.getSize(widthSpec);
+            int lockedHeight = MeasureSpec.getSize(heightSpec);
+
+            if (lockedWidth == 0 && lockedHeight == 0) {
+                throw new IllegalArgumentException(
+                        "Both width and height cannot be zero -- watch out for scrollable containers");
+            }
+
+            // Get the padding of the border background.
+            int hPadding = getPaddingLeft() + getPaddingRight();
+            int vPadding = getPaddingTop() + getPaddingBottom();
+
+            // Resize the preview frame with correct aspect ratio.
+            lockedWidth -= hPadding;
+            lockedHeight -= vPadding;
+
+            if (lockedHeight > 0 && (lockedWidth > lockedHeight * localRatio)) {
+                lockedWidth = (int) (lockedHeight * localRatio + .5);
+            }
+            else {
+                lockedHeight = (int) (lockedWidth / localRatio + .5);
+            }
+
+            // Add the padding of the border.
+            lockedWidth += hPadding;
+            lockedHeight += vPadding;
+
+            // Ask children to follow the new preview dimension.
+            super.onMeasure(MeasureSpec.makeMeasureSpec(lockedWidth,
+                            MeasureSpec.EXACTLY),
+                    MeasureSpec.makeMeasureSpec(lockedHeight,
+                            MeasureSpec.EXACTLY));
+        }
     }
 
-    @Override
-    public int getHeight() {
-      return(v.getHeight());
+    /**
+     * Locks the aspect ratio of the {@link AspectLockedFrameLayout} to the one inferred by
+     * the current width and height
+     */
+    public void lockAspectRatioImmediately() {
+        AspectLockedFrameLayout.this.setAspectRatio(AspectLockedFrameLayout.this.getWidth() / AspectLockedFrameLayout.this.getHeight());
     }
-  }
+
+    /**
+     * Locks the aspect ratio of the {@link AspectLockedFrameLayout} to the one on the next
+     * layout change
+     */
+    public void lockAspectRatioOnLayoutChange() {
+        final ViewTreeObserver aspectRatioLockedLayoutObserver = getViewTreeObserver();
+        aspectRatioLockedLayoutObserver.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+
+            @Override
+            public void onGlobalLayout() {
+                AspectLockedFrameLayout.this.setAspectRatio(AspectLockedFrameLayout.this.getWidth() / AspectLockedFrameLayout.this.getHeight());
+                if (aspectRatioLockedLayoutObserver != null && aspectRatioLockedLayoutObserver.isAlive()) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                        aspectRatioLockedLayoutObserver.removeOnGlobalLayoutListener(this);
+                    }
+                    else {
+                        aspectRatioLockedLayoutObserver.removeGlobalOnLayoutListener(this);
+                    }
+                }
+            }
+        });
+    }
+
+    public void setAspectRatioSource(View v) {
+        this.aspectRatioSource = new ViewAspectRatioSource(v);
+    }
+
+    public void setAspectRatioSource(AspectRatioSource aspectRatioSource) {
+        this.aspectRatioSource = aspectRatioSource;
+    }
+
+    // from com.android.camera.PreviewFrameLayout, with slight
+    // modifications
+
+    public void setAspectRatio(double aspectRatio) {
+        if (aspectRatio <= 0.0) {
+            throw new IllegalArgumentException(
+                    "aspect ratio must be positive");
+        }
+
+        if (this.aspectRatio != aspectRatio) {
+            this.aspectRatio = aspectRatio;
+            requestLayout();
+        }
+    }
+
+    public interface AspectRatioSource {
+        int getWidth();
+
+        int getHeight();
+    }
+
+    private static class ViewAspectRatioSource implements
+            AspectRatioSource {
+        private View v = null;
+
+        ViewAspectRatioSource(View v) {
+            this.v = v;
+        }
+
+        @Override
+        public int getWidth() {
+            return (v.getWidth());
+        }
+
+        @Override
+        public int getHeight() {
+            return (v.getHeight());
+        }
+    }
 }


### PR DESCRIPTION
I came across a scenario where I needed to lock the aspect ratio of the whole view, and I felt a bit sad about having to write by myself the boilerplate for what seems like the most common use case of the layout.

This PR adds a couple of methods to shortcut this. They are javadoced and mentioned in the README.

Thanks!